### PR TITLE
Add parser for cfn-lint output

### DIFF
--- a/lintly/parsers.py
+++ b/lintly/parsers.py
@@ -216,8 +216,7 @@ class CfnLintParser(BaseLintParser):
         marker = False
         current_violation = None
         for line in output.strip().splitlines():
-            match = regex.match(line.strip())
-            if match:
+            if regex.match(line):
                 marker = True
                 current_violation = line
             elif marker:

--- a/lintly/parsers.py
+++ b/lintly/parsers.py
@@ -229,7 +229,7 @@ class CfnLintParser(BaseLintParser):
 
                 violation = Violation(line=int(line_number),
                                       column=int(column),
-                                      code=f"`{code}`",
+                                      code="`{}`".format(code),
                                       message=message)
                 violations[path].append(violation)
 

--- a/lintly/parsers.py
+++ b/lintly/parsers.py
@@ -225,10 +225,12 @@ class CfnLintParser(BaseLintParser):
                 path, line_number, column = line.split(":")
                 path = self._normalize_path(path)
 
+                code, message = current_violation.split(" ", 1)
+
                 violation = Violation(line=int(line_number),
                                       column=int(column),
-                                      code="`cfn-lint`",
-                                      message=current_violation)
+                                      code=f"`{code}`",
+                                      message=message)
                 violations[path].append(violation)
 
                 next_line_is_path = False

--- a/lintly/parsers.py
+++ b/lintly/parsers.py
@@ -229,7 +229,7 @@ class CfnLintParser(BaseLintParser):
 
                 violation = Violation(line=int(line_number),
                                       column=int(column),
-                                      code="`{}`".format(code),
+                                      code="{}".format(code),
                                       message=message)
                 violations[path].append(violation)
 

--- a/lintly/parsers.py
+++ b/lintly/parsers.py
@@ -229,7 +229,7 @@ class CfnLintParser(BaseLintParser):
 
                 violation = Violation(line=int(line_number),
                                       column=int(column),
-                                      code="{}".format(code),
+                                      code=code,
                                       message=message)
                 violations[path].append(violation)
 

--- a/tests/linters_output/cfn-lint.txt
+++ b/tests/linters_output/cfn-lint.txt
@@ -1,0 +1,8 @@
+W2001 Parameter UnusedParameter not used.
+templates/template.yaml:2:9
+
+W2001 Parameter AnotherOne not used.
+templates/template.yaml:5:9
+
+E1012 Ref PrincipalOrgID not found as a resource or parameter
+templates/template2.yaml:7:9

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,6 +1,7 @@
 import abc
 import os
 import unittest
+
 try:
     from unittest.mock import patch
 except ImportError:
@@ -175,6 +176,7 @@ class CfnLintParserTestCase(ParserTestCaseMixin, unittest.TestCase):
             {'line': 5, 'column': 9, 'code': '`cfn-lint`', 'message': 'W2001 Parameter AnotherOne not used.'}
         ],
         "templates/template2.yaml": [
-            {'line': 7, 'column': 9, 'code': '`cfn-lint`', 'message': 'E1012 Ref PrincipalOrgID not found as a resource or parameter'},
+            {'line': 7, 'column': 9, 'code': '`cfn-lint`',
+             'message': 'E1012 Ref PrincipalOrgID not found as a resource or parameter'},
         ]
     }

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -172,11 +172,11 @@ class CfnLintParserTestCase(ParserTestCaseMixin, unittest.TestCase):
 
     expected_violations = {
         "templates/template.yaml": [
-            {'line': 2, 'column': 9, 'code': '`cfn-lint`', 'message': 'W2001 Parameter UnusedParameter not used.'},
-            {'line': 5, 'column': 9, 'code': '`cfn-lint`', 'message': 'W2001 Parameter AnotherOne not used.'}
+            {'line': 2, 'column': 9, 'code': '`W2001`', 'message': 'Parameter UnusedParameter not used.'},
+            {'line': 5, 'column': 9, 'code': '`W2001`', 'message': 'Parameter AnotherOne not used.'}
         ],
         "templates/template2.yaml": [
-            {'line': 7, 'column': 9, 'code': '`cfn-lint`',
-             'message': 'E1012 Ref PrincipalOrgID not found as a resource or parameter'},
+            {'line': 7, 'column': 9, 'code': '`E1012`',
+             'message': 'Ref PrincipalOrgID not found as a resource or parameter'},
         ]
     }

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -163,3 +163,18 @@ class BlackParserTestCase(ParserTestCaseMixin, unittest.TestCase):
     @patch('lintly.parsers.BlackParser._get_working_dir', return_value='/Users/jouyuy/Dev/workspace/Lintly')
     def test_parse_violations(self, _get_working_dir_mock):
         super(BlackParserTestCase, self).test_parse_violations()
+
+
+class CfnLintParserTestCase(ParserTestCaseMixin, unittest.TestCase):
+    parser = PARSERS['cfn-lint']
+    linter_output_file_name = 'cfn-lint.txt'
+
+    expected_violations = {
+        "templates/template.yaml": [
+            {'line': 2, 'column': 9, 'code': '`cfn-lint`', 'message': 'W2001 Parameter UnusedParameter not used.'},
+            {'line': 5, 'column': 9, 'code': '`cfn-lint`', 'message': 'W2001 Parameter AnotherOne not used.'}
+        ],
+        "templates/template2.yaml": [
+            {'line': 7, 'column': 9, 'code': '`cfn-lint`', 'message': 'E1012 Ref PrincipalOrgID not found as a resource or parameter'},
+        ]
+    }

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -172,11 +172,11 @@ class CfnLintParserTestCase(ParserTestCaseMixin, unittest.TestCase):
 
     expected_violations = {
         "templates/template.yaml": [
-            {'line': 2, 'column': 9, 'code': '`W2001`', 'message': 'Parameter UnusedParameter not used.'},
-            {'line': 5, 'column': 9, 'code': '`W2001`', 'message': 'Parameter AnotherOne not used.'}
+            {'line': 2, 'column': 9, 'code': 'W2001', 'message': 'Parameter UnusedParameter not used.'},
+            {'line': 5, 'column': 9, 'code': 'W2001', 'message': 'Parameter AnotherOne not used.'}
         ],
         "templates/template2.yaml": [
-            {'line': 7, 'column': 9, 'code': '`E1012`',
+            {'line': 7, 'column': 9, 'code': 'E1012',
              'message': 'Ref PrincipalOrgID not found as a resource or parameter'},
         ]
     }


### PR DESCRIPTION
**Problem**
No parser existed for cfn-lint output. 

**Solution**
Add a parser for cfn-lint output, with tests and example output.

