### PR TITLE
Base commit status context on format unless --context is provided

### DIFF
--- a/lintly/backends/github.py
+++ b/lintly/backends/github.py
@@ -99,9 +99,10 @@ class GitHubBackend(BaseGitBackend):
 
     supports_pr_reviews = True
 
-    def __init__(self, token, project):
+    def __init__(self, token, project, context):
         super(GitHubBackend, self).__init__(token, project)
         self.client = Github(token, user_agent=GITHUB_USER_AGENT, per_page=DEFAULT_PER_PAGE)
+        self.context = context
 
     def _should_delete_comment(self, comment):
         return LINTLY_IDENTIFIER in comment.body
@@ -199,6 +200,6 @@ class GitHubBackend(BaseGitBackend):
             'state': state,
             'description': description,
             'target_url': target_url,
-            'context': 'Lintly'
+            'context': self.context
         }
         client.post(url, data)

--- a/lintly/builds.py
+++ b/lintly/builds.py
@@ -21,7 +21,9 @@ class LintlyBuild(object):
         self.linter_output = linter_output
 
         self.project = Project(config.repo)
-        self.git_client = GitHubBackend(token=config.api_key, project=self.project, context=config.context)
+
+        context = config.context or "Lintly/{0}".format(config.format)
+        self.git_client = GitHubBackend(token=config.api_key, project=self.project, context=context)
 
         # All violations found from the linting output
         self._all_violations = {}

--- a/lintly/builds.py
+++ b/lintly/builds.py
@@ -21,7 +21,7 @@ class LintlyBuild(object):
         self.linter_output = linter_output
 
         self.project = Project(config.repo)
-        self.git_client = GitHubBackend(token=config.api_key, project=self.project)
+        self.git_client = GitHubBackend(token=config.api_key, project=self.project, context=config.context)
 
         # All violations found from the linting output
         self._all_violations = {}

--- a/lintly/cli.py
+++ b/lintly/cli.py
@@ -28,6 +28,9 @@ logger = logging.getLogger(__name__)
 @click.option('--commit-sha',
               envvar='LINTLY_COMMIT_SHA',
               help='The commit Lintly is running against.')
+@click.option('--context',
+              default='Lintly',
+              help='The context used for commit statuses')
 @click.option('--format',
               envvar='LINTLY_FORMAT',
               type=click.Choice(list(PARSERS.keys())),

--- a/lintly/cli.py
+++ b/lintly/cli.py
@@ -28,14 +28,13 @@ logger = logging.getLogger(__name__)
 @click.option('--commit-sha',
               envvar='LINTLY_COMMIT_SHA',
               help='The commit Lintly is running against.')
-@click.option('--context',
-              default='Lintly',
-              help='The context used for commit statuses')
 @click.option('--format',
               envvar='LINTLY_FORMAT',
               type=click.Choice(list(PARSERS.keys())),
               default='unix',
               help='The linting output format Lintly should expect to receive')
+@click.option('--context',
+              help='Override the commit status context')
 # @click.option('--site-url',
 #               envvar='LINTLY_SITE_URL',
 #               default='github.com',

--- a/lintly/config.py
+++ b/lintly/config.py
@@ -33,6 +33,10 @@ class Config(object):
         return self.cli_config['commit_sha'] or getattr(self.ci, 'commit_sha')
 
     @property
+    def context(self):
+        return self.cli_config['context']
+
+    @property
     def api_key(self):
         return self.cli_config['api_key']
 

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -1,0 +1,43 @@
+import pytest
+from lintly.config import Config
+from lintly import builds
+from unittest.mock import patch, Mock
+
+
+@pytest.fixture(
+    params=[
+        # format, context, expected_context
+        ("black", None, "Lintly/black"),
+        ("cfn-lint", None, "Lintly/cfn-lint"),
+        ("flake8", "my-flake8-context", "my-flake8-context"),
+    ]
+)
+def format_and_context(request):
+    return request.param
+
+
+@pytest.fixture
+def config(format_and_context):
+    cli_config = {
+        "api_key": "api_key",
+        "repo": "owner/repo",
+        "pr": 1,
+        "format": format_and_context[0],
+        "commit_sha": "xyz123notarealsha",
+        "context": format_and_context[1],
+        "post_status": True,
+    }
+
+    return Config(cli_config)
+
+
+@pytest.fixture
+def GitHubBackend(monkeypatch):
+    ghb_mock = Mock()
+    monkeypatch.setattr(builds, "GitHubBackend", ghb_mock)
+    return ghb_mock
+
+
+def test_lintly_build(config, GitHubBackend, format_and_context):
+    builds.LintlyBuild(config, "Some linter output")
+    assert GitHubBackend.call_args[1]["context"] == format_and_context[2]

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -1,8 +1,12 @@
 import pytest
-from unittest.mock import Mock
 
 from lintly import builds
 from lintly.config import Config
+
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 
 @pytest.fixture(

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -1,7 +1,8 @@
 import pytest
-from lintly.config import Config
+from unittest.mock import Mock
+
 from lintly import builds
-from unittest.mock import patch, Mock
+from lintly.config import Config
 
 
 @pytest.fixture(


### PR DESCRIPTION
## Problem
Lintly hardcoded commit status context to `Lintly` which resulted in commit statuses for multiple parsers run on the same PR being overwritten. 

## Solution
Allow the context to be determined in one of two ways:
1.) Generated as "Lintly/{format}" (e.g., Lintly/black, Lintly/cfn-lint, Lintly/unix)
2.) Overridden with a `context` option (e.g., --context my-custom-context)

## Proof
![image](https://user-images.githubusercontent.com/1668741/53669364-7929d600-3c3c-11e9-8530-24cf79109765.png)
