### PR TITLE
Make lintly work in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,4 @@ stages:
 - Support for config file
 - Auto-detect linters
 - GitLab support
+- Azure Devops

--- a/lintly/ci.py
+++ b/lintly/ci.py
@@ -113,6 +113,24 @@ class CodeBuild(object):
         return git.head()
 
 
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables
+# Note: variables with '.' in the name will have dot replaced with underscore
+# in actual environment
+class AzureDevOps(object):
+
+    @property
+    def pr(self):
+        return os.environ.get('SYSTEM_PULLREQUEST_PULLREQUESTNUMBER', None)
+
+    @property
+    def repo(self):
+        return os.environ['BUILD_REPOSITORY_ID']
+
+    @property
+    def commit_sha(self):
+        return os.environ['BUILD_SOURCEVERSION']
+
+
 def find_ci_provider():
     ci_providers = [
         ('TRAVIS', Travis),
@@ -121,6 +139,7 @@ def find_ci_provider():
         ('SHIPPABLE', Shippable),
         ('SEMAPHORE', Semaphore),
         ('CODEBUILD_BUILD_ID', CodeBuild),
+        ('AZURE_HTTP_USER_AGENT', AzureDevOps),
     ]
 
     for ci_env_var, ci_cls in ci_providers:

--- a/lintly/cli.py
+++ b/lintly/cli.py
@@ -50,6 +50,8 @@ logger = logging.getLogger(__name__)
 @click.option('--log',
               is_flag=True,
               help='Send Lintly debug logs to the console.')
+@click.option('--exit-zero/--no-exit-zero', default=False,
+              help="Whether Lintly should exit with error code indicating amount of violations or not")
 def main(**options):
     """Slurp up linter output and send it to a GitHub PR review."""
     configure_logging(log_all=options.get('log'))
@@ -69,8 +71,11 @@ def main(**options):
         logger.info('Not a PR. Lintly is exiting.')
         sys.exit(0)
 
+    exit_code = 0
     # Exit with the number of files that have violations
-    sys.exit(len(build.violations))
+    if not options['exit_zero']:
+        exit_code = len(build.violations)
+    sys.exit(exit_code)
 
 
 def configure_logging(log_all=False):

--- a/lintly/git.py
+++ b/lintly/git.py
@@ -1,7 +1,7 @@
-import sh
+import subprocess
 
 
 def head():
     """Returns the head commit"""
-    sha = sh.git('rev-parse', 'HEAD').stdout[:40]
+    sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'])[:40]
     return sha.decode('utf-8')

--- a/lintly/projects.py
+++ b/lintly/projects.py
@@ -1,4 +1,3 @@
-
 class Project(object):
 
     def __init__(self, full_name):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ dependencies = [
     'jinja2<3.0',
     'PyGithub<2.0',
     'python-gitlab<2.0',
-    'sh<1.13',
     'six',
 ]
 


### PR DESCRIPTION
* Use subprocess instead of sh for compatibility.
  sh hasnt't worked in windows for a very long time and replaceing sh.git
  call with subprocess.check_output() was easy way to fix the issue in
  cross-platform manner. Fixes #12
* Added support for azure devops pipelines
* Added --exit-zero flag to prevent exit codes