### PR TITLE
Fix black command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Now you will see a review with linting errors...
     ```
 - [black](https://black.readthedocs.io/en/stable/)
     ```
-    $ black --check | lintly --format=black
+    $ black . --check 2>&1 >/dev/null | lintly --format=black
     ```
 - [pylint](https://www.pylint.org/)
     - For pylint you must use the `json` output format.


### PR DESCRIPTION
## Problem
Command to check code with black in README is missing the path and not piping the output to Lintly.

## Solution
* Fix missing path
* Redirect stderr to stdout since black writes to stderr and Lintly is reading from stdout