### PR TITLE
Fix requirements, upgrade click package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,12 @@
-tox
+Jinja2<3.0
+PyGithub<2.0
+cached-property<2.0
+ci-py
+click<7.0
+codecov
+coverage
 flake8
 mock
 pytest
-codecov
-coverage
+python-gitlab<2.0
+tox

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 dependencies = [
     'ci-py',
     'cached-property<2.0',
-    'click<7.0',
+    'click<8.0',
     'Jinja2<3.0',
     'PyGithub<2.0',
     'python-gitlab<2.0',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ dependencies = [
     'ci-py',
     'cached-property<2.0',
     'click<7.0',
-    'jinja2<3.0',
+    'Jinja2<3.0',
     'PyGithub<2.0',
     'python-gitlab<2.0',
     'six',


### PR DESCRIPTION
# Problem
[Installation](https://github.com/grantmcconnaughey/Lintly/blob/ef6f0deebe3091cbffd1f1dfbcd7511ddd1f8934/setup.py#L11) of older version of `click` package resulting in conflicts with other packages, for example latest `black` package requires [click>=7.1.2](https://github.com/psf/black/blob/master/setup.py#L71) results in:
```
lintly 0.5.0 has requirement click<7.0, but you have click 7.1.2.
```

# Solution
Requires `click<8.0`. The new major version [7.x](https://click.palletsprojects.com/en/7.x/changelog/#version-7-0) has no changes for [click.command](https://click.palletsprojects.com/en/7.x/api/#click.command) decorator or [click.testing.CliRunner](https://click.palletsprojects.com/en/7.x/api/#click.testing.CliRunner).

# Proof

`pip check` reports no broken requirements:
<img width="572" alt="Screenshot 2020-10-06 at 2 33 04 AM" src="https://user-images.githubusercontent.com/1216537/95135271-978f7600-077d-11eb-8491-7f46d234a102.png">

Tests passing:
<img width="1637" alt="Screenshot 2020-10-06 at 2 33 22 AM" src="https://user-images.githubusercontent.com/1216537/95135341-af66fa00-077d-11eb-8085-6478c67127be.png">


Thanks!