### PR TITLE
unpinned Jinja2 version to fix ImportError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Jinja2<3.0
+Jinja2
 PyGithub<2.0
 cached-property<2.0
 ci-py


### PR DESCRIPTION
The new version 2.1.0 of `MarkupSafe` which was released today leads to an `ImportError` in the installed version of `Jinja2` which is pinned to `<3`. Either pinning `MarkupSafe` to 2.0.1 or installing the latest version of `Jinja2` seems to fix the problem. Since the tests ran successful, I went with the latter and unpinned the version.

<details>

```python
 Traceback (most recent call last):
  File "/usr/local/bin/lintly", line 5, in <module>
    from lintly.cli import main
  File "/usr/local/lib/python3.7/site-packages/lintly/cli.py", line 7, in <module>
    from .builds import LintlyBuild
  File "/usr/local/lib/python3.7/site-packages/lintly/builds.py", line 14, in <module>
    from .backends.github import GitHubBackend
  File "/usr/local/lib/python3.7/site-packages/lintly/backends/__init__.py", line 1, in <module>
    from .github import GitHubBackend  # noqa
  File "/usr/local/lib/python3.7/site-packages/lintly/backends/github.py", line 11, in <module>
    from lintly.formatters import (
  File "/usr/local/lib/python3.7/site-packages/lintly/formatters.py", line 6, in <module>
    from jinja2 import Environment, FileSystemLoader
  File "/usr/local/lib/python3.7/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/usr/local/lib/python3.7/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File "/usr/local/lib/python3.7/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/local/lib/python3.7/site-packages/markupsafe/__init__.py)
```

</details>

resolves #54 