### PR TITLE
Issue #54 - Upgrade dependencies pinning

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-Jinja2<3.0
+Jinja2<4.0
 PyGithub<2.0
 cached-property<2.0
 ci-py
-click<7.0
+click<9.0
 codecov
 coverage
 flake8
 mock
 pytest
-python-gitlab<2.0
+python-gitlab<4.0
 tox

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,10 @@ from setuptools import find_packages, setup
 dependencies = [
     'ci-py',
     'cached-property<2.0',
-    'click<8.0',
-    'Jinja2<3.0',
+    'click<9.0',
+    'Jinja2<4.0',
     'PyGithub<2.0',
-    'python-gitlab<2.0',
+    'python-gitlab<4.0',
     'six',
 ]
 


### PR DESCRIPTION
This is an alternative to PR #52 that upgrades all pinned version to the latest one.
This PR also has a commit that adds Python 3.10 to the testing matrix, and the tests pass.